### PR TITLE
Remove 64 bit UEFI from 32 bit version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,4 +72,5 @@ jobs:
           for asset in ./artifact/*; do
             assets+=("-a" "$asset")
           done
+          sleep 1
           hub release edit "${assets[@]}" -m "This release was built on the latest code and may be unstable. USE AT YOUR OWN RISK!" $todayDate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,12 @@ jobs:
       env:
         ARCH: amd64
       run: |
-        env
         sudo -E ./build.sh
     - 
       name: Build for i686
       env:
         ARCH: i686
       run: |
-        env
         sudo -E ./build.sh
     -
       name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,14 @@ jobs:
       env:
         ARCH: amd64
       run: |
+        env
         sudo -E ./build.sh
     - 
       name: Build for i686
       env:
         ARCH: i686
       run: |
+        env
         sudo -E ./build.sh
     -
       name: Upload artifacts

--- a/build.sh
+++ b/build.sh
@@ -68,14 +68,14 @@ start_time="$(date -u +%s)"
 
 # Install dependencies to build odysseyn1x
 apt-get update
-apt-get install -y --no-install-recommends wget debootstrap \
+apt-get install -y --no-install-recommends wget debootstrap grub-pc-bin \
     mtools squashfs-tools xorriso ca-certificates curl \
     libusb-1.0-0-dev gcc make gzip xz-utils unzip libc6-dev
 
 if [ "$ARCH" = 'amd64' ]; then
     REPO_ARCH='amd64' # Debian's 64-bit repos are "amd64"
     KERNEL_ARCH='amd64' # Debian's 32-bit kernels are suffixed "amd64"
-    apt install -y --no-install-recommends grub-efi-amd64-bin grub-pc-bin
+    apt install -y --no-install-recommends grub-efi-amd64-bin
 else
     # remove grub-efi-amd64-bin. grub-mkrescue doesn't have any architecture configuration other than the set of installed packages.
     apt-get remove -y --allow-remove-essential grub-efi-amd64-bin grub-efi-amd64-signed
@@ -83,7 +83,7 @@ else
     # Install depencies to build odysseyn1x for i686
     dpkg --add-architecture i386
     apt-get update
-    apt install -y --no-install-recommends libusb-1.0-0-dev:i386 gcc-multilib grub-pc-bin
+    apt install -y --no-install-recommends libusb-1.0-0-dev:i386 gcc-multilib
     #grub-efi-ia32-bin
     REPO_ARCH='i386' # Debian's 32-bit repos are "i386"
     KERNEL_ARCH='686' # Debian's 32-bit kernels are suffixed "-686"

--- a/build.sh
+++ b/build.sh
@@ -68,19 +68,22 @@ start_time="$(date -u +%s)"
 
 # Install dependencies to build odysseyn1x
 apt-get update
-apt-get install -y --no-install-recommends wget debootstrap grub-pc-bin \
+apt-get install -y --no-install-recommends wget debootstrap \
     mtools squashfs-tools xorriso ca-certificates curl \
     libusb-1.0-0-dev gcc make gzip xz-utils unzip libc6-dev
 
 if [ "$ARCH" = 'amd64' ]; then
     REPO_ARCH='amd64' # Debian's 64-bit repos are "amd64"
     KERNEL_ARCH='amd64' # Debian's 32-bit kernels are suffixed "amd64"
-    apt install -y --no-install-recommends grub-efi-amd64-bin
+    apt install -y --no-install-recommends grub-efi-amd64-bin grub-pc-bin
 else
+    # remove all grub packges (specifically grub-efi-amd64-*). grub-mkrescue doesn't have any architecture configuration other than the set of installed packages.
+    apt-get remove -y '.grub.'
+    
     # Install depencies to build odysseyn1x for i686
     dpkg --add-architecture i386
     apt-get update
-    apt install -y --no-install-recommends libusb-1.0-0-dev:i386 gcc-multilib grub-efi-ia32-bin
+    apt install -y --no-install-recommends libusb-1.0-0-dev:i386 gcc-multilib grub-efi-ia32-bin grub-pc-bin
     REPO_ARCH='i386' # Debian's 32-bit repos are "i386"
     KERNEL_ARCH='686' # Debian's 32-bit kernels are suffixed "-686"
 fi

--- a/build.sh
+++ b/build.sh
@@ -83,7 +83,8 @@ else
     # Install depencies to build odysseyn1x for i686
     dpkg --add-architecture i386
     apt-get update
-    apt install -y --no-install-recommends libusb-1.0-0-dev:i386 gcc-multilib grub-efi-ia32-bin grub-pc-bin
+    apt install -y --no-install-recommends libusb-1.0-0-dev:i386 gcc-multilib grub-pc-bin
+    #grub-efi-ia32-bin
     REPO_ARCH='i386' # Debian's 32-bit repos are "i386"
     KERNEL_ARCH='686' # Debian's 32-bit kernels are suffixed "-686"
 fi

--- a/build.sh
+++ b/build.sh
@@ -77,8 +77,8 @@ if [ "$ARCH" = 'amd64' ]; then
     KERNEL_ARCH='amd64' # Debian's 32-bit kernels are suffixed "amd64"
     apt install -y --no-install-recommends grub-efi-amd64-bin grub-pc-bin
 else
-    # remove all grub packges (specifically grub-efi-amd64-*). grub-mkrescue doesn't have any architecture configuration other than the set of installed packages.
-    apt-get remove -y 'grub.'
+    # remove grub-efi-amd64-bin. grub-mkrescue doesn't have any architecture configuration other than the set of installed packages.
+    apt-get remove -y --allow-remove-essential grub-efi-amd64-bin grub-efi-amd64-signed
     
     # Install depencies to build odysseyn1x for i686
     dpkg --add-architecture i386

--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ if [ "$ARCH" = 'amd64' ]; then
     apt install -y --no-install-recommends grub-efi-amd64-bin grub-pc-bin
 else
     # remove all grub packges (specifically grub-efi-amd64-*). grub-mkrescue doesn't have any architecture configuration other than the set of installed packages.
-    apt-get remove -y '.grub.'
+    apt-get remove -y 'grub.'
     
     # Install depencies to build odysseyn1x for i686
     dpkg --add-architecture i386

--- a/build.sh
+++ b/build.sh
@@ -80,11 +80,7 @@ else
     # Install depencies to build odysseyn1x for i686
     dpkg --add-architecture i386
     apt-get update
-    apt install -y --no-install-recommends libusb-1.0-0-dev:i386 gcc-multilib
-
-    # test later
-	#apt install -y --no-install-recommends grub-efi-ia32-bin
-
+    apt install -y --no-install-recommends libusb-1.0-0-dev:i386 gcc-multilib grub-efi-ia32-bin
     REPO_ARCH='i386' # Debian's 32-bit repos are "i386"
     KERNEL_ARCH='686' # Debian's 32-bit kernels are suffixed "-686"
 fi

--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,6 @@ else
     dpkg --add-architecture i386
     apt-get update
     apt install -y --no-install-recommends libusb-1.0-0-dev:i386 gcc-multilib
-    #grub-efi-ia32-bin
     REPO_ARCH='i386' # Debian's 32-bit repos are "i386"
     KERNEL_ARCH='686' # Debian's 32-bit kernels are suffixed "-686"
 fi

--- a/build.sh
+++ b/build.sh
@@ -69,17 +69,22 @@ start_time="$(date -u +%s)"
 # Install dependencies to build odysseyn1x
 apt-get update
 apt-get install -y --no-install-recommends wget debootstrap grub-pc-bin \
-    grub-efi-amd64-bin mtools squashfs-tools xorriso ca-certificates curl \
+    mtools squashfs-tools xorriso ca-certificates curl \
     libusb-1.0-0-dev gcc make gzip xz-utils unzip libc6-dev
 
 if [ "$ARCH" = 'amd64' ]; then
     REPO_ARCH='amd64' # Debian's 64-bit repos are "amd64"
     KERNEL_ARCH='amd64' # Debian's 32-bit kernels are suffixed "amd64"
+    apt install -y --no-install-recommends grub-efi-amd64-bin
 else
     # Install depencies to build odysseyn1x for i686
     dpkg --add-architecture i386
     apt-get update
     apt install -y --no-install-recommends libusb-1.0-0-dev:i386 gcc-multilib
+
+    # test later
+	#apt install -y --no-install-recommends grub-efi-ia32-bin
+
     REPO_ARCH='i386' # Debian's 32-bit repos are "i386"
     KERNEL_ARCH='686' # Debian's 32-bit kernels are suffixed "-686"
 fi


### PR DESCRIPTION
Tested to menu with my laptop and qemu:
`sudo qemu-system-i386 -m 2G -enable-kvm -cdrom <path to x86 infinity>`
`sudo qemu-system-x86_64 -m 2G -enable-kvm -cdrom <path to x86 or x64 infinity>`

You'll need to revert the merge of #8 to merge this.